### PR TITLE
Typo in ex 2.2

### DIFF
--- a/Podminene_psti_a_Bayes.ipynb
+++ b/Podminene_psti_a_Bayes.ipynb
@@ -591,7 +591,7 @@
     "\\begin{aligned}\n",
     "P(F) &= P(F\\cap H) + P(F \\cap D) \\\\\n",
     "&= P(F|H)P(H) + P(F|D)P(D) \\\\\n",
-    "&= 0.1 \\cdot 0.7 + 0.5 \\cdot 0.3 = 0.085.\n",
+    "&= 0.1 \\cdot 0.7 + 0.05 \\cdot 0.3 = 0.085.\n",
     "\\end{aligned}\n",
     "$$\n",
     "\n",


### PR DESCRIPTION
5% is 0.05 instead of 0.5